### PR TITLE
Fix breakage from Documentable API change

### DIFF
--- a/.travis/docker-entrypoint.sh
+++ b/.travis/docker-entrypoint.sh
@@ -6,6 +6,9 @@ set -x
 apk update
 apk upgrade
 
+# Install node.js - dependency of Documentable
+apk add nodejs
+
 # Report status
 raku --version
 which zef

--- a/lib/Rakudoc.rakumod
+++ b/lib/Rakudoc.rakumod
@@ -36,6 +36,7 @@ sub process-type-pod-files(
             # because of that we take the first element
             pod => load($f).first,
             filename => $f.basename.IO.extension('').Str,
+            source-path => $f.Str,
         );
 
         @results.push($documentable);


### PR DESCRIPTION
Documentable::Primary has a new mandatory constructor parameter, which broke `rakudoc`. This should solve #7.