### PR TITLE
add is for io path & not string, which $dir is if as cli option from …

### DIFF
--- a/lib/Rakudoc/CMD.rakumod
+++ b/lib/Rakudoc/CMD.rakumod
@@ -91,7 +91,7 @@ package Rakudoc::CMD {
         my @dirs = $dir ?? $dir !! get-doc-locations;
         my @subdirs = $routine ?? 'Type' !! Kind.enums.keys;
 
-        @doc-dirs = cross :with({$^a.add($^b)}), @dirs, @subdirs;
+        @doc-dirs = cross :with({$^a.IO.add($^b)}), @dirs, @subdirs;
 
         my $search-results;
         if $routine {


### PR DESCRIPTION
…(-d) 

see the readme for usage, per, for example: 
"raku -Ilib bin/rakudoc -d=../doc/doc Num.rand"
trying this was how I discovered.