### PR TITLE
Migrate to Pod::Utils

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    container:
+      image: rakudo-star:latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Raku version
+      run: raku -v
+
+    - name: Install dependencies
+      run: zef install --deps-only --/test --test-depends .
+
+    - name: Run tests
+      run: zef test -v --debug .

--- a/Changes
+++ b/Changes
@@ -10,6 +10,9 @@ Revision history for rakudoc
     - Only use the first candidate from each repo when searching for doc
       files (i.e., don't look in older versions of a distribution)
 
+0.2.5  2023-03-01T18:30:00-04:00
+    - Change deprecated dependency Pod::Utilities to Pod::Utils
+
 0.2.4  2021-05-03T20:40:29-04:00
     - Fix portability issue (do not call .read-dist on
       CompUnit::Repository::Distribution)

--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,7 @@
   "build-depends": [
   ],
   "depends": [
-    "Pod::Utilities:ver<0.0.1+>"
+    "Pod::Utils:ver<0.0.2+>"
   ],
   "description": "A tool for reading Raku documentation",
   "license": "Artistic-2.0",
@@ -35,5 +35,5 @@
     "File::Directory::Tree",
     "File::Temp:ver<0.0.8+>"
   ],
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/lib/Rakudoc/Documentable.rakumod
+++ b/lib/Rakudoc/Documentable.rakumod
@@ -1,5 +1,5 @@
-use Pod::Utilities;
-use Pod::Utilities::Build;
+use Pod::Utils;
+use Pod::Utils::Build;
 
 #| Enum to classify all "kinds" of Documentable
 enum Kind is export (Type      => "type"     , Language => "language",


### PR DESCRIPTION
I tried to fetch `Pod::Utilites` distributive from https://github.com/antoniogamiz/Pod-Utilities, it redirects me to https://github.com/JJ/raku-pod-utils. Looks like `Pod::Utilites` is [deprecated](https://raku.land/github:antoniogamiz/Pod::Utilities) and `Pod::Utils` should be used instead.

This fix is tested manually:

```
[kostas@webtech-omen rakudoc]$ zef install .
===> Searching for missing dependencies: Pod::Utils:ver<0.0.2+>, IO::MiddleMan:ver<1.001003+>
===> Testing: Pod::Utils:ver<0.0.2>:auth<zef:jjmerelo>
===> Testing [OK] for Pod::Utils:ver<0.0.2>:auth<zef:jjmerelo>
===> Testing: IO::MiddleMan:ver<1.001004>:auth<zef:raku-community-modules>
===> Testing [OK] for IO::MiddleMan:ver<1.001004>:auth<zef:raku-community-modules>
===> Testing: rakudoc:ver<0.2.5>:auth<github:Raku>:api<1>
===> Testing [OK] for rakudoc:ver<0.2.5>:auth<github:Raku>:api<1>
===> Installing: Pod::Utils:ver<0.0.2>:auth<zef:jjmerelo>
===> Installing: IO::MiddleMan:ver<1.001004>:auth<zef:raku-community-modules>
===> Installing: rakudoc:ver<0.2.5>:auth<github:Raku>:api<1>

1 bin/ script [rakudoc] installed to:
/opt/rakudo/rakudo-star-2022.12/share/perl6/site/bin
```

Also added github CI/CD support as a bonus 😁